### PR TITLE
Replace templated config selectors for user Slurm job profiles

### DIFF
--- a/roles/jupyterhub/defaults/main.yml
+++ b/roles/jupyterhub/defaults/main.yml
@@ -24,6 +24,13 @@ jupyterhub_config:
   spawner:
     start_timeout: 180 # seconds
 
+jupyterhub_profiles:
+  - default:
+      display_name: default
+      options:
+        req_memory: "2"
+        req_nprocs: "1"
+
 jupyterhub_services:
   dask_gateway: CStgn1NN8DogQR1KajuoQfye1qNRqx6zsh
 

--- a/roles/jupyterhub/templates/environments/dashboards.yaml
+++ b/roles/jupyterhub/templates/environments/dashboards.yaml
@@ -16,6 +16,6 @@ dependencies:
   - voila >= 0.2.7
   - streamlit >= 0.76
   - dash >= 1.19
+  - batchspawner==1.3.0
   - pip:
-      - git+https://github.com/jupyterhub/batchspawner.git
       - jhub-apps==2024.2.1rc1

--- a/roles/jupyterhub/templates/environments/jupyterhub.yaml
+++ b/roles/jupyterhub/templates/environments/jupyterhub.yaml
@@ -9,11 +9,11 @@ dependencies:
   - escapism==1.0.1
   - jupyterhub-idle-culler==1.2.1
   - sqlalchemy==1.4.46
+  - batchspawner==1.3.0
   - pip:
       - nebari_jupyterhub_theme==2023.4.1
       - python-keycloak==0.26.1
       - jupyterhub-traefik-proxy==1.1.0
       # jupyterhub-ssh has not made a release yet
       - git+https://github.com/yuvipanda/jupyterhub-ssh.git
-      - git+https://github.com/jupyterhub/batchspawner.git
       - jhub-apps==2024.2.1rc1

--- a/roles/jupyterhub/templates/environments/jupyterhub.yaml
+++ b/roles/jupyterhub/templates/environments/jupyterhub.yaml
@@ -16,4 +16,5 @@ dependencies:
       - jupyterhub-traefik-proxy==1.1.0
       # jupyterhub-ssh has not made a release yet
       - git+https://github.com/yuvipanda/jupyterhub-ssh.git
+      - git+https://github.com/jupyterhub/wrapspawner.git
       - jhub-apps==2024.2.1rc1

--- a/roles/jupyterhub/templates/environments/jupyterlab.yaml
+++ b/roles/jupyterhub/templates/environments/jupyterlab.yaml
@@ -44,6 +44,7 @@ dependencies:
   - black
   - isort
   - importnb
+  - batchspawner==1.3.0
 
   - pip:
       # vscode jupyterlab launcher

--- a/roles/jupyterhub/templates/jupyterhub_config.py
+++ b/roles/jupyterhub/templates/jupyterhub_config.py
@@ -144,68 +144,6 @@ class QHubHPCSpawnerBase(SlurmSpawner):
         # Could be overridden by subclasses, but mainly useful for testing
         return format_template(self.batch_script, **subvars)
 
-
-
-
-{% if jupyterhub_qhub_options_form %}
-    # data from form submission is {key: [value]}
-    # we need to convert the formdata to a key value dict
-    def options_from_form(self, data):
-        return {key: value[0] for key, value in data.items()}
-
-    main_options_form = f'''
-    <div class="form-group row">
-    <label for="memory" class="col-2 col-form-label">JupyterLab Memory (GB)</label>
-    <div class="col-10">
-        <input class="form-control" type="number" value="1" id="memory" name="memory">
-    </div>
-    </div>
-    <div class="form-group row">
-    <label for="nprocs" class="col-2 col-form-label">JupyterLab CPUs</label>
-    <div class="col-10">
-        <input class="form-control" type="number" value="1" id="nprocs" name="nprocs">
-    </div>
-    </div>
-    <div class="form-group row">
-    <label for="partition" class="col-2 col-form-label">Slurm Partition</label>
-    <div class="col-10">
-        <select class="form-select" aria-label="Slurm Queue" id="partition" name="partition">
-        <option value="general">general</option>
-    {% for item in groups %}
-    {% if item.startswith('partition-')%}
-        <option value="{{ item[10:] }}">{{ item[10:] }}</option>
-    {% endif %}
-    {% endfor %}
-        </select>
-    </div>
-    </div>
-    '''
-
-    conda_options_form = f'''
-    {% raw %}
-    <div class="form-group row">
-    <label for="conda_environment_prefix" class="col-2 col-form-label">Conda Environment</label>
-    <div class="col-10">
-        <select class="form-select" aria-label="Conda Environment" id="conda_environment_prefix" name="conda_environment_prefix">
-    {''.join([f'<option value="{_[1]}">{_[0]}</option>' for _ in conda_envs_w_packages(jupyterlab_packages)])}
-        </select>
-    </div>
-    </div>
-    {% endraw %}
-    '''
-
-    def options_form(self, spawner):
-        ## Not currently working - idea is to omit conda env from spawner form
-        ## for dashboards, since already selected a conda env
-        #if spawner.orm_spawner.user_options and 'presentation_type' in spawner.orm_spawner.user_options:
-        #  self.log.info("In options_form")
-        #  if spawner.user_options['presentation_type']:
-        #    return self.main_options_form # Omit the conda env dropdown since that is chosen per dashboard
-
-        # Display full form including conda env dropdown
-        return ''.join([self.main_options_form, self.conda_options_form])
-{% endif %}
-
 # Assign Qhub Spawner
 class QHubHPCSpawner(QHubHPCSpawnerBase):
     pass
@@ -216,7 +154,7 @@ c.JupyterHub.default_url = '/hub/home'
 c.JupyterHub.template_paths = []
 c.JupyterHub.extra_handlers = []
 
-c.JupyterHub.spawner_class = QHubHPCSpawner
+c.JupyterHub.spawner_class = 'wrapspawner.ProfilesSpawner'
 
 c.SlurmSpawner.start_timeout = {{ jupyterhub_config.spawner.start_timeout }}
 c.QHubHPCSpawner.default_url = '/lab'
@@ -224,6 +162,7 @@ c.QHubHPCSpawner.default_url = '/lab'
 # default values for batch spawner
 c.QHubHPCSpawner.req_memory = '1' # GB
 c.QHubHPCSpawner.req_nprocs = '1'
+c.QHubHPCSpawner.req_partition = 'general'
 c.QHubHPCSpawner.req_conda_environment_prefix = '{{ miniforge_home }}/envs/{{ jupyterhub_lab_environment | basename | splitext | first }}'
 c.QHubHPCSpawner.req_prologue = '''
 # ensure user has link to the shared directory, if it exists
@@ -312,6 +251,24 @@ def generate_batch_script(spawner):
 
 c.QHubHPCSpawner.batch_script = generate_batch_script
 
+USER_PROFILES = {{ jupyterhub_profiles | tojson }}
+
+def set_profiles(user_profiles: list):
+    """Set the profiles for the ProfilesSpawner."""
+    profiles = []
+    for profile_dict in user_profiles:
+        profile_name, profile_data = next(iter(profile_dict.items()))
+        profiles.append((
+            profile_data['display_name'],
+            profile_name,
+            QHubHPCSpawner,
+            dict(**profile_data['options'])
+        ))
+    return profiles
+
+
+# User profiles
+c.ProfilesSpawner.profiles = set_profiles(USER_PROFILES)
 
 # ===== adding api tokens for external services =======
 c.JupyterHub.services = [

--- a/roles/miniforge/defaults/main.yml
+++ b/roles/miniforge/defaults/main.yml
@@ -1,7 +1,7 @@
 ---
 miniforge_enabled: false
-miniforge_version: 4.11.0-0
-miniforge_sha256: 49268ee30d4418be4de852dda3aa4387f8c95b55a76f43fb1af68dcbf8b205c3
+miniforge_version: 23.11.0-0
+miniforge_sha256: 3dfdcc162bf0df83b5025608dc2acdbbc575bd416b75701fb5863343c0517a78
 miniforge_home: /opt/conda
 miniforge_envs:
   - /opt/conda/envs/


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://nebari.dev/community
-->

## Reference Issues or PRs

<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create a link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->

## What does this implement/fix?

- Replace the previous git installation of batchspawner with the latest release,` batchspawner==1.3.0`
- Add batchspawner into jupyterlab environment, as it is a requirement to launch the slurm jobs
- Set jupyterlab environment as base environment for running the sbatch script
- Updated miniforge version, as it ships a newer mamba version for more stable/fast environment builds
- Added new function to generate user profiles base on new config options `jupyterhub_profiles`
- Add new config option `jupyterhub_profiles`

_Put a `x` in the boxes that apply_

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds a feature)
- [ ] Breaking change (fix or feature that would cause existing features not to work as expected)
- [ ] Documentation Update
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build related changes
- [ ] Other (please describe):

## Testing

- [ ] Did you test the pull request locally?
- [ ] Did you add new tests?

## Documentation

<!--
  Where is this feature or API documented?

  - If docs exist:
    - Update any references, if relevant. This includes Guides and Nebari Internals docs.
  - If no docs exist:
    - Create a stub for documentation, including bullet points for how to use the feature, code snippets (including from
      happy path tests), etc.
We want to ensure that the content produced for Nebari is accessible; if you are making significant contributions,
please address the access-centred guidelines in your content and complete our checklist. Thanks to @isabela-pf for this checklist :)
-->

### Access-centered content checklist

#### Text styling

- [ ] The content is written with [plain language](https://www.plainlanguage.gov/guidelines/) (where relevant).
- [ ] If there are headers, they use the proper header tags (with only one level-one header: `H1` or `#` in markdown).
- [ ] All links describe where they link to (for example, check the [Nebari website](https://nebari.dev/)).
- [ ] This content adheres to the Nebari style guides.

#### Non-text content

- [ ] All content is represented as text (for example, images need alt text, and videos need captions or descriptive transcripts).
- [ ] If there are emojis, there are not more than three in a row.
- [ ] Don't use [flashing GIFs or videos](https://www.w3.org/TR/UNDERSTANDING-WCAG20/seizure-does-not-violate.html).
- [ ] If the content were to be read as plain text, it still makes sense, and no information is missing.

## Any other comments?

<!--
Please be aware that we are a loose team of volunteers, so patience is necessary;
assistance handling other issues is very welcome.
We value all user contributions. If we are slow to review, either the pull request needs some benchmarking, tinkering,
convincing, etc., or the reviewers are likely busy. In either case,
we ask for your understanding during the
review process.
Thanks for contributing to Nebari 🙏🏼!
-->
